### PR TITLE
adds passing test for throwing a warning when prop types in playerfor…

### DIFF
--- a/src/Utils/index.js
+++ b/src/Utils/index.js
@@ -2,17 +2,18 @@ export const propTypeWarnings = () => {
   const originalConsoleError = global.console.error;
 
 //I think this doesn't work nicely with checkPropTypes. This utility function works with console.errors in the browser console. With checkPropTypes, the warning isn't coming through the browser?
+//but this isn't even being called with a warning in the browser...
 global.console.error = (...args) => {
-    console.log('!!!!');
-    console.log(...args);
     const propTypeErrors = [/Failed prop type/, /Warning: Failed/];
-
     //array.some(callback(element)) -- if callback returns true for any item in array, returns true.
     //test() method runs a search for a match between a regex object and a string
     //regexobj.test(str). Returns boolean
     if (propTypeErrors.some(warning => warning.test(args[0]))) {
-      throw new Error(args[0]);
+      throw new Error('Prop Type Failure');
     }
     console.error(originalConsoleError);
   }
 }
+
+//This is only running if I manually call console.error in the test. If I use check-prop-types library, a console.error is (I think) running, but for some reason isn't triggering this to run...
+//this is also running during the failed test 'should render without errors', if a prop type warning is thrown in the browser.

--- a/src/components/PlayerForm/PlayerForm.js
+++ b/src/components/PlayerForm/PlayerForm.js
@@ -58,7 +58,7 @@ const PlayerForm = props => {
 }
 
 PlayerForm.propTypes = {
-  setPlayerNames: PropTypes.func
+  setPlayerNames: PropTypes.func,
 }
 
 export default PlayerForm;

--- a/src/components/PlayerForm/playerform.test.js
+++ b/src/components/PlayerForm/playerform.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import PlayerForm from './PlayerForm';
-import checkPropTypes from 'check-prop-types';
+import checkPropTypes, { assertPropTypes } from 'check-prop-types';
+import { propTypeWarnings } from '../../Utils/index';
 
 const setUp = (props={}) => {
   let component = shallow(<PlayerForm {...props}/>)
@@ -11,6 +12,8 @@ const setUp = (props={}) => {
 describe('testing PlayerForm component', () => {
   let component;
   beforeEach(() => {
+    //calling the spy here, causes the util function to be called, because the console.error with the wrong prop type is being called immediately upon rendering the component.
+    // propTypeWarnings();
     const props = {
       setPlayerNames: () => 'Fake fn'
     }
@@ -37,12 +40,31 @@ describe('testing PlayerForm component', () => {
   })
 
   describe('testing PropTypes', () => {
-    const expectedProps = {
-      //HALLEFUCKINGLUJAH ITS FAILING HERE
-      //I've never been so jazzed to have a test fail
-      setPlayerNames: () => 'Fake fn',
-    }
-    const propsErr = checkPropTypes(PlayerForm.propTypes, expectedProps, 'props', PlayerForm);
-    expect(propsErr).toBeUndefined();
+
+    // //this isn't doing anything when using check-prop-types library.
+    // beforeEach(() => {
+    //   propTypeWarnings();
+    // })
+
+    it ('should not throw a warning', () => {
+      const expectedProps = {
+        setPlayerNames: () => 'Fake fn',
+      }
+      const propsErr = checkPropTypes(PlayerForm.propTypes, expectedProps, 'prop', PlayerForm);
+      expect(propsErr).toBeUndefined();
+    })
+
+    it ('should throw a warning', () => {
+      const expectedProps = {
+        setPlayerNames: 47,
+      }
+      //checkPropTypes should now throw a warning, which, because I've set up the spy to watch for console.error warnings, should turn that into a thrown exception, with an argument of 'Prop Type Failure'. But why is it not throwing the exception?
+      // expect(() => {
+      //   assertPropTypes(PlayerForm.propTypes, expectedProps, 'prop', PlayerForm)
+      // }).toThrow('Prop Type Failure');
+
+      const propsErr = (/Failed prop type/).test(checkPropTypes(PlayerForm.propTypes, expectedProps, 'prop', PlayerForm));
+      expect(propsErr).toBe(true);
+    })
   })
 })


### PR DESCRIPTION
…m arent validated. Still having trouble getting utility function to run, that turns console.error into thrown exception. See commented out code for more info.